### PR TITLE
fix(expose-gps): tunnel to xCore :10000, not :2000

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Notes:
 ### Self-update (zipapp distribution)
 If you run the zipapp build (a single-file `openmower` executable), you can self-update from GitHub releases:
 ```bash
-openmower self-update                  # update to latest release
-openmower self-update -v v1.2.3        # update to specific tag
-openmower self-update --repo owner/repo # override repo (defaults to ClemensElflein/openmower-cli)
-openmower self-update --dry-run        # show what would be done
+openmower update-self                  # update to latest release
+openmower update-self -v v1.2.3        # update to specific tag
+openmower update-self --repo owner/repo # override repo (defaults to ClemensElflein/openmower-cli)
+openmower update-self --dry-run        # show what would be done
 ```
 The command replaces the currently running zipapp with the downloaded version atomically.
 

--- a/src/openmower_cli/constants.py
+++ b/src/openmower_cli/constants.py
@@ -54,3 +54,6 @@ XCORE_CONFIG_FILE: Path = Path(os.path.expanduser("~/.config/openmower-cli/xcore
 # Default ports for exposing xESC and IMU
 ESC_DEFAULT_PORT = 65102
 GPS_DEFAULT_PORT = 2000
+
+# GPS raw-passthrough TCP port on the xCore (fw-openmower-v2: DebugTCPInterface, gps_service.hpp:50)
+GPS_XCORE_PORT = 10000

--- a/src/openmower_cli/openmower_commands.py
+++ b/src/openmower_cli/openmower_commands.py
@@ -11,7 +11,7 @@ import requests
 from openmower_cli.console import info, error, success, message
 from openmower_cli.constants import FW_BIN_NAME, get_env, XCORE_CONFIG_FILE, BOOTLOADER_BIN_NAME
 from openmower_cli.helpers import fetch_github_release_zip, run
-from openmower_cli.constants import ESC_DEFAULT_PORT, GPS_DEFAULT_PORT
+from openmower_cli.constants import ESC_DEFAULT_PORT, GPS_DEFAULT_PORT, GPS_XCORE_PORT
 
 openmower_app = typer.Typer(help="OpenMower Commands")
 
@@ -295,8 +295,10 @@ def serial_bridge(
 
 
 @openmower_app.command("expose-gps")
-def expose_gps():
-    f"""Expose the GPS device over TCP (port {GPS_DEFAULT_PORT})."""
-    info("You can now run u-center and connect to port 2000")
-    code = _run_socat(target_ip="172.16.78.150", target_port=2000, port=GPS_DEFAULT_PORT)
+def expose_gps(
+    port: int = typer.Option(GPS_DEFAULT_PORT, "--port", "-p", help=f"TCP port to listen on (default: {GPS_DEFAULT_PORT})"),
+):
+    """Expose the xCore GPS raw-passthrough over TCP so u-center can connect."""
+    info(f"You can now run u-center and connect to port {port}")
+    code = _run_socat(target_ip="172.16.78.150", target_port=GPS_XCORE_PORT, port=port)
     raise typer.Exit(code=code)


### PR DESCRIPTION
## Summary

`openmower expose-gps` tunneled to `172.16.78.150:2000`, but the v2
firmware's GPS `DebugTCPInterface` listens on **:10000**
[(`fw-openmower-v2/src/services/gps_service/gps_service.hpp:50`)](https://github.com/xtech/fw-openmower-v2/blob/main/src/services/gps_service/gps_service.hpp#L50). The
command therefore always failed with "Connection refused" on OMOSv2 

## Changes

- Add `GPS_XCORE_PORT = 10000` constant; point `socat` there.
- Add `--port/-p` option, aligning with `expose-xesc`.
- CLI listener default stays at `2000` → existing u-center bookmarks
  keep working.
- Legacy v1 path untouched.