### PR TITLE
Add update-firmware --owner/repo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ openmower update-self --dry-run        # show what would be done
 ```
 The command replaces the currently running zipapp with the downloaded version atomically.
 
+### Update firmware
+```bash
+openmower update-firmware                    # update firmware to latest release
+openmower update-firmware --from-pr 37       # update firmware to specific PR
+openmower update-firmware --repo owner/repo  # override repo
+```
+
 ## Development
 Clone and install in editable mode:
 ```bash

--- a/src/openmower_cli/openmower_commands.py
+++ b/src/openmower_cli/openmower_commands.py
@@ -9,7 +9,7 @@ import typer
 import requests
 
 from openmower_cli.console import info, error, success, message
-from openmower_cli.constants import FW_BIN_NAME, get_env, XCORE_CONFIG_FILE, BOOTLOADER_BIN_NAME
+from openmower_cli.constants import FW_BIN_NAME, FW_REPO, get_env, XCORE_CONFIG_FILE, BOOTLOADER_BIN_NAME
 from openmower_cli.helpers import fetch_github_release_zip, run
 from openmower_cli.constants import ESC_DEFAULT_PORT, GPS_DEFAULT_PORT, GPS_XCORE_PORT
 
@@ -42,7 +42,12 @@ def update_firmware(
         None,
         "--from-pr",
         help="Download firmware built for a specific pull request number.",
-    )
+    ),
+    repo: str = typer.Option(
+        FW_REPO,
+        "--repo",
+        help="GitHub repo slug 'owner/name' to fetch firmware releases from.",
+    ),
 ):
     """Update mower firmware to the latest release from fw-openmower-v2.
 
@@ -56,9 +61,6 @@ def update_firmware(
     if not firmware:
         error("Environment variable FIRMWARE is not set. Please set FIRMWARE to your firmware identifier and retry.")
         raise typer.Exit(code=2)
-
-    from openmower_cli.constants import FW_REPO
-    repo = FW_REPO
 
     # Decide source of firmware
     if from_pr is not None:


### PR DESCRIPTION
To be able to test custom firmware as a non core-team developer, it is
useful to be able to upload a custom firmware image via

  openmower update-firmware --repo owner/repo

This pull request does just that.